### PR TITLE
Fix create account

### DIFF
--- a/src/app/core/users/http/controllers/UsersController.ts
+++ b/src/app/core/users/http/controllers/UsersController.ts
@@ -9,7 +9,14 @@ class UsersController {
     response: Response,
     next: NextFunction,
   ): Promise<Response | void> {
-    const { email, full_name, password } = request.body
+    const {
+      email,
+      full_name,
+      password,
+      financial_objective,
+      monthly_income,
+      like_be_called,
+    } = request.body
 
     const createUser = container.resolve(CreateUserService)
 
@@ -18,6 +25,9 @@ class UsersController {
         email,
         password,
         full_name,
+        financial_objective,
+        monthly_income,
+        like_be_called,
       })
 
       return response.json({

--- a/src/app/core/users/infra/entities/Profile.ts
+++ b/src/app/core/users/infra/entities/Profile.ts
@@ -26,6 +26,9 @@ class Profile {
   financial_objective?: string
 
   @Column()
+  monthly_income?: string
+
+  @Column()
   avatar_url?: string
 
   @UpdateDateColumn()

--- a/src/app/core/users/infra/repositories/UsersRepository.ts
+++ b/src/app/core/users/infra/repositories/UsersRepository.ts
@@ -10,12 +10,22 @@ class UsersRepository implements UsersRepositoryProvider {
     this.ormRepository = getRepository(User)
   }
 
-  async create({ full_name, email, password }: CreateUser): Promise<User> {
+  async create({
+    full_name,
+    email,
+    password,
+    financial_objective,
+    like_be_called,
+    monthly_income,
+  }: CreateUser): Promise<User> {
     const user = this.ormRepository.create({
       email,
       password,
       profile: {
         full_name,
+        financial_objective,
+        like_be_called,
+        monthly_income,
       },
     })
 

--- a/src/app/core/users/services/CreateUserService.test.ts
+++ b/src/app/core/users/services/CreateUserService.test.ts
@@ -22,11 +22,17 @@ describe('CreateUserService', () => {
     const full_name = 'Example'
     const email = 'example@domoney.com'
     const password = '123456'
+    const like_be_called = 'Example'
+    const monthly_income = '1000'
+    const financial_objective = 'make_extra_income'
 
     const user = await createUserService.execute({
       email,
       full_name,
       password,
+      like_be_called,
+      monthly_income,
+      financial_objective,
     })
 
     expect(user.email).toBe(email)
@@ -36,7 +42,6 @@ describe('CreateUserService', () => {
     const full_name = 'Example'
     const email = 'example@domoney.com'
     const password = '123456'
-
     await fakeUsersRepository.create({
       email,
       full_name,

--- a/src/app/core/users/services/CreateUserService.ts
+++ b/src/app/core/users/services/CreateUserService.ts
@@ -35,6 +35,9 @@ class CreateUserService {
       email: data.email,
       password: passwordHashed,
       full_name: data.full_name,
+      like_be_called: data.like_be_called,
+      financial_objective: data.financial_objective,
+      monthly_income: data.monthly_income,
     })
 
     const user = { id, email }

--- a/src/app/core/users/types/index.ts
+++ b/src/app/core/users/types/index.ts
@@ -3,9 +3,11 @@ import { Joi } from 'celebrate'
 
 import { User, Session, Profile } from '@/app/core/users/infra/entities'
 
-export type CreateUser = {
-  full_name: string
-} & Pick<User, 'email' | 'password'>
+export type CreateUser = Pick<User, 'email' | 'password'> &
+  Pick<
+    Profile,
+    'full_name' | 'financial_objective' | 'monthly_income' | 'like_be_called'
+  >
 export type AuthenticateUser = Pick<User, 'email' | 'password'>
 export type UpdateUser = Omit<Profile, 'id' | 'user' | 'updated_at'>
 
@@ -36,6 +38,9 @@ export const createUserSchema = {
   email: Joi.string().email().required(),
   password: Joi.string().required(),
   full_name: Joi.string().required(),
+  financial_objective: Joi.string().required(),
+  monthly_income: Joi.string().required(),
+  like_be_called: Joi.string().required(),
 }
 
 export const authenticateUserSchema = {

--- a/src/database/migrations/1645652137094-AddMonthlyIncomeColumnIntoUserProfile.ts
+++ b/src/database/migrations/1645652137094-AddMonthlyIncomeColumnIntoUserProfile.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm'
+
+export class AddMonthlyIncomeColumnIntoUserProfile1645652137094
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'user_profiles',
+      new TableColumn({
+        name: 'monthly_income',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('user_profiles', 'monthly_income')
+  }
+}


### PR DESCRIPTION
## Motivation

Precisamos de mais alguns dados para enviar no ato de criar uma conta, sendo os dados de renda mensal, objetivo financeiro e como gostaria de ser chamado.

## Proposed solution

- [x] Criarmos uma coluna chamada `monthly_income` para representar a renda mensal, dentro da tabela `user_profiles`
- [x] Adicionarmos `like_be_called`, `monthly_income` e `financial_objective` no body da requisição para criarmos o usuário.
